### PR TITLE
Move child creation from __enter__ to __init__

### DIFF
--- a/lambda_multiprocessing/main.py
+++ b/lambda_multiprocessing/main.py
@@ -245,15 +245,14 @@ class Pool:
 
         self._closed = False
 
-    def __enter__(self):
-        self._closed = False
-
         if self.num_processes > 0:
             self.children = [Child() for _ in range(self.num_processes)]
         else:
             # create one 'child' which will just do work in the main thread
             self.children = [Child(main_proc=True)]
 
+
+    def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/lambda_multiprocessing/test_main.py
+++ b/lambda_multiprocessing/test_main.py
@@ -282,6 +282,24 @@ class TestMap(TestCase):
         with Pool() as p:
             p.map(square, range(10**3))
 
+    def test_without_with(self):
+        # check that the standard library Pool
+        # can do .map() without `with`
+        p = multiprocessing.Pool(3)
+        ret = p.map(square, [1,2])
+        self.assertEqual(ret, [1,2*2])
+        p.close()
+        p.join()
+
+        # now check that this library can do it
+        p = Pool(3)
+        ret = p.map(square, [1,2])
+        self.assertEqual(ret, [1,2*2])
+        p.close()
+        p.join()
+
+        
+
 class TestMapAsync(TestCase):
     def test_simple(self):
         args = range(5)
@@ -432,7 +450,7 @@ class TestMoto(TestCase):
         self.assertEqual(ret, data)
 
 class TestSlow(TestCase):
-    @unittest.skip('Very slow')
+    #@unittest.skip('Very slow')
     def test_memory_leak(self):
         for i in range(10**2):
             with Pool() as p:


### PR DESCRIPTION
This fixes #5 

Since `multiprocessing.Pool` can be used without `with`, that means `__enter__` doesn't need to do anything.