### PR TITLE
swap mock_s3 to mock_aws

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
 
     steps:

--- a/lambda_multiprocessing/requirements_test.txt
+++ b/lambda_multiprocessing/requirements_test.txt
@@ -1,3 +1,3 @@
-moto[s3]
+moto[s3]>=5
 boto3
 tox>=2.7.0

--- a/lambda_multiprocessing/test_main.py
+++ b/lambda_multiprocessing/test_main.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import os
 
 import boto3
-from moto import mock_s3
+from moto import mock_aws
 
 # add an overhead for duration when asserting the duration of child processes
 # if other processes are hogging CPU, make this bigger
@@ -419,7 +419,7 @@ class TestMoto(TestCase):
                 r = p.apply_async(sleep, (t,))
                 pass # makes traceback from __exit__ easier to read
 
-    @mock_s3
+    @mock_aws
     def test_moto(self):
         bucket_name = 'mybucket'
         key = 'my-file'

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,11 @@ setup(
    'Operating System :: OS Independent',
    'License :: OSI Approved :: MIT License',
    'Programming Language :: Python :: 3',
-   'Programming Language :: Python :: 3.7',
    'Programming Language :: Python :: 3.8',
    'Programming Language :: Python :: 3.9',
    'Programming Language :: Python :: 3.10',
+   'Programming Language :: Python :: 3.11',
+   'Programming Language :: Python :: 3.12',
  ],
  keywords=['python', 'AWS', 'Amazon', 'Lambda', 'multiprocessing', 'pool', 'concurrency'],
  packages=find_packages()


### PR DESCRIPTION
Update moto to use `mock_aws` instead of `mock_s3`. 

(Unit tests on master were failing because of breaking change in moto.)

This only impacts unit tests, not the library itself.