### PR TITLE
Deadlock Solution

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -113,8 +113,11 @@ Then you can run the unit tests with:
 python3 -m unittest
 ```
 
-`CICD` is for the GitHub Actions which run unit tests and integration tests.
+The tests themselves are defined in `lambda_multiprocessing/test_main.py`.
+
+`CICD` is for the GitHub Actions which run the unit tests and integration tests.
 You probably don't need to touch those.
+
 
 ## Design
 

--- a/lambda_multiprocessing/main.py
+++ b/lambda_multiprocessing/main.py
@@ -12,7 +12,7 @@ from itertools import repeat
 class Request:
     pass
 
-class Task[Request]:
+class Task(Request):
     func: Callable
     args: List
     kwds: Dict
@@ -24,10 +24,10 @@ class Task[Request]:
         self.kwds = kwds or {}
         self.id = id or uuid4()
 
-class QuitSignal[Request]:
+class QuitSignal(Request):
     pass
 
-class RunBatchSignal[Request]:
+class RunBatchSignal(Request):
     pass
     
 # this is what we send back through the pipe from child to parent
@@ -35,7 +35,7 @@ class Response:
     id: UUID
     pass
 
-class SuccessResponse:
+class SuccessResponse(Response):
     result: Any
     def __init__(self, id: UUID, result: Any):
         self.result = result
@@ -43,7 +43,7 @@ class SuccessResponse:
 
 # processing the task raised an exception
 # we save the exception in this object
-class FailResponse:
+class FailResponse(Response):
     exception: Exception
     def __init__(self, id: UUID, exception: Exception):
         self.id = id

--- a/lambda_multiprocessing/main.py
+++ b/lambda_multiprocessing/main.py
@@ -1,12 +1,53 @@
 from multiprocessing import TimeoutError, Process, Pipe
 from multiprocessing.connection import Connection
-from typing import Any, Iterable, List, Dict, Tuple, Union, Optional
+from typing import Any, Iterable, List, Dict, Tuple, Union, Optional, Callable
 from uuid import uuid4, UUID
 import random
 import os
 from time import time
 from select import select
-import signal
+from itertools import repeat
+
+# This is what we send down the pipe from parent to child
+class Request:
+    pass
+
+class Task[Request]:
+    func: Callable
+    args: List
+    kwds: Dict
+    id: UUID
+
+    def __init__(self, func, args=(), kwds={}, id=None):
+        self.func = func
+        self.args = args
+        self.kwds = kwds or {}
+        self.id = id or uuid4()
+
+class QuitSignal[Request]:
+    pass
+
+class RunBatchSignal[Request]:
+    pass
+    
+# this is what we send back through the pipe from child to parent
+class Response:
+    id: UUID
+    pass
+
+class SuccessResponse:
+    result: Any
+    def __init__(self, id: UUID, result: Any):
+        self.result = result
+        self.id = id
+
+# processing the task raised an exception
+# we save the exception in this object
+class FailResponse:
+    exception: Exception
+    def __init__(self, id: UUID, exception: Exception):
+        self.id = id
+        self.exception = exception
 
 class Child:
     proc: Process
@@ -19,12 +60,12 @@ class Child:
     # does not include the termination command from parent to child
     queue_sz: int = 0
 
-    # parent_conn.send()  to give stuff to the child
+    # parent_conn.send(Request)  to give stuff to the child
     # parent_conn.recv() to get results back from child
     parent_conn: Connection
     child_conn: Connection
 
-    result_cache: Dict[UUID, Tuple[Any, Exception]] = {}
+    response_cache: Dict[UUID, Tuple[Any, Exception]] = {}
 
     _closed: bool = False
 
@@ -49,47 +90,81 @@ class Child:
     #                         {id: (None, err)} if func raised exception err
     # [None, True] -> exit gracefully (write nothing to the pipe)
     def spin(self) -> None:
+        quit_signal = False
         while True:
-            (job, quit_signal) = self.child_conn.recv()
+            req_buf = []
+            # first read in tasks until we get a pause/quit signal
+            while True:
+                request = self.child_conn.recv()
+                if isinstance(request, Task):
+                    req_buf.append(request)
+                elif isinstance(request, QuitSignal):
+                    # don't quit yet. Finish what's in the buffer.
+                    quit_signal |= True
+                    break # stop reading new stuff from the pipe
+                elif isinstance(request, RunBatchSignal):
+                    # stop reading from Pipe, process what's in the request buffer
+                    break
+            result_buf = []
+            for req in req_buf:
+                assert isinstance(req, Task)
+                # process the result
+                result = self._do_work(req)
+                result_buf.append(result)
+
+            # send all the results
+            for result in result_buf:         
+                self.child_conn.send(result)
+
             if quit_signal:
                 break
-            else:
-                (id, func, args, kwds) = job
-                result = self._do_work(id, func, args, kwds)
-                self.child_conn.send(result)
         self.child_conn.close()
 
-    def _do_work(self, id, func, args, kwds) -> Union[Tuple[Any, None], Tuple[None, Exception]]:
+    # applies the function, catching any exception if it occurs
+    def _do_work(self, task: Task) -> Response:
         try:
-            ret = {id: (func(*args, **kwds), None)}
+            result = task.func(*task.args, **task.kwds)
         except Exception as e:
             # how to handle KeyboardInterrupt?
-            ret = {id: (None, e)}
-        assert isinstance(list(ret.keys())[0], UUID)
-        return ret
+            resp = FailResponse(id=task.id, exception=e)
+        else:
+            resp = SuccessResponse(id=task.id, result=result)
+        return resp
 
-    def submit(self, func, args=(), kwds=None) -> 'AsyncResult':
+    # this sends a task to the child
+    # if as_batch=False, the child will start work on it immediately
+    # If as_batch=True, the child will load this into it's local buffer
+    # but won't start processing until we send a RunBatchSignal with self.run_batch()
+    def submit(self, func, args=(), kwds=None, as_batch=False) -> 'AsyncResult':
         if self._closed:
             raise ValueError("Cannot submit tasks after closure")
-        if kwds is None:
-            kwds = {}
-        id = uuid4()
-        self.parent_conn.send([(id, func, args, kwds), None])
+        request = Task(func=func, args=args, kwds=kwds)
+
+        self.parent_conn.send(request)
         if self.main_proc:
             self.child_conn.recv()
-            ret = self._do_work(id, func, args, kwds)
+            ret = self._do_work(request)
             self.child_conn.send(ret)
+        elif not as_batch:
+            # treat this as a batch of 1
+            self.run_batch()
         self.queue_sz += 1
-        return AsyncResult(id=id, child=self)
+        return AsyncResult(id=request.id, child=self)
+
+    # non-blocking
+    # Tells the child to start commencing work on all tasks sent up until now
+    def run_batch(self):
+        self.parent_conn.send(RunBatchSignal())
 
     # grab all results in the pipe from child to parent
-    # save them to self.result_cache
-    def flush(self):
+    # save them to self.response_cache
+    def flush_results(self):
         # watch out, when the other end is closed, a termination byte appears, so .poll() returns True
         while (not self.parent_conn.closed) and (self.queue_sz > 0) and self.parent_conn.poll(0):
             result = self.parent_conn.recv()
-            assert isinstance(list(result.keys())[0], UUID)
-            self.result_cache.update(result)
+            id = result.id
+            assert id not in self.response_cache
+            self.response_cache[id] = result
             self.queue_sz -= 1
 
     # prevent new tasks from being submitted
@@ -99,10 +174,10 @@ class Child:
         if not self._closed:
             if not self.main_proc:
                 # send quit signal to child
-                self.parent_conn.send([None, True])
+                self.parent_conn.send(QuitSignal())
             else:
                 # no child process to close
-                self.flush()
+                self.flush_results()
                 self.child_conn.close()
 
             # keep track of closure,
@@ -124,7 +199,7 @@ class Child:
             finally:
                 self.proc.close()
 
-        self.flush()
+        self.flush_results()
         self.parent_conn.close()
 
 
@@ -157,13 +232,13 @@ class AsyncResult:
         assert isinstance(id, UUID)
         self.id = id
         self.child = child
-        self.result: Union[Tuple[Any, None], Tuple[None, Exception]] = None
+        self.response: Result = None
 
-    # assume the result is in the self.child.result_cache
-    # move it into self.result
+    # assume the result is in the self.child.response_cache
+    # move it into self.response
     def _load(self):
-        self.result = self.child.result_cache[self.id]
-        del self.child.result_cache[self.id] # prevent memory leak
+        self.response = self.child.response_cache[self.id]
+        del self.child.response_cache[self.id] # prevent memory leak
 
     # Return the result when it arrives.
     # If timeout is not None and the result does not arrive within timeout seconds
@@ -171,15 +246,15 @@ class AsyncResult:
     # If the remote call raised an exception then that exception will be reraised by get().
     # .get() must remember the result
     # and return it again multiple times
-    # delete it from the Child.result_cache to avoid memory leak
+    # delete it from the Child.response_cache to avoid memory leak
     def get(self, timeout=None):
-        if self.result is not None:
-            (response, ex) = self.result
-            if ex:
-                raise ex
-            else:
-                return response
-        elif self.id in self.child.result_cache:
+        if self.response is not None:
+            if isinstance(self.response, SuccessResponse):
+                return self.response.result
+            elif isinstance(self.response, FailResponse):
+                assert isinstance(self.response.exception, Exception)
+                raise self.response.exception
+        elif self.id in self.child.response_cache:
             self._load()
             return self.get(0)
         else:
@@ -191,12 +266,12 @@ class AsyncResult:
 
     # Wait until the result is available or until timeout seconds pass.
     def wait(self, timeout=None):
-        start_t = time()
-        if self.result is None:
-            self.child.flush()
+        if self.response is None:
+            start_t = time()
+            self.child.flush_results()
             # the result we want might not be the next result
             # it might be the 2nd or 3rd next
-            while (self.id not in self.child.result_cache) and \
+            while (self.id not in self.child.response_cache) and \
                   ((timeout is None) or (time() - timeout < start_t)):
                 if timeout is None:
                     self.child.parent_conn.poll()
@@ -205,23 +280,23 @@ class AsyncResult:
                     remaining = timeout - elapsed_so_far
                     self.child.parent_conn.poll(remaining)
                 if self.child.parent_conn.poll(0):
-                    self.child.flush()
+                    self.child.flush_results()
 
     # Return whether the call has completed.
     def ready(self):
-        self.child.flush()
-        return self.result or (self.id in self.child.result_cache)
+        self.child.flush_results()
+        return self.response or (self.id in self.child.response_cache)
 
     # Return whether the call completed without raising an exception.
     # Will raise ValueError if the result is not ready.
     def successful(self):
-        if self.result is None:
+        if self.response is None:
             if not self.ready():
                 raise ValueError("Result is not ready")
             else:
                 self._load()
 
-        return self.result[1] is None
+        return isinstance(self.response, SuccessResponse)
 
 # map_async and starmap_async return a single AsyncResult
 # which is a list of actual results
@@ -231,7 +306,7 @@ class AsyncResultList(AsyncResult):
         self.child_results = child_results
         self.result: List[Union[Tuple[Any, None], Tuple[None, Exception]]] = None
 
-    # assume the result is in the self.child.result_cache
+    # assume the result is in the self.child.response_cache
     # move it into self.result
     def _load(self):
         for c in self.child_results:
@@ -243,28 +318,19 @@ class AsyncResultList(AsyncResult):
     # If the remote call raised an exception then that exception will be reraised by get().
     # .get() must remember the result
     # and return it again multiple times
-    # delete it from the Child.result_cache to avoid memory leak
+    # delete it from the Child.response_cache to avoid memory leak
     def get(self, timeout=None):
-        if timeout:
-            end_t = time() + timeout
-        else:
-            end_t = None
+        self.wait(timeout)
+        assert self.ready()
 
         results = []
         for (i, c) in enumerate(self.child_results):
-            # Consider cumulative timeout
-            if timeout is not None:
-                timeout_remaining = end_t - time()
-            else:
-                timeout_remaining = None
-
             try:
-                result = c.get(timeout=timeout_remaining)
+                result = c.get(0)
             except Exception:
                 print(f"Exception raised for {i}th task out of {len(self.child_results)}")
-                # terminate remaining children
                 for c2 in self.child_results[i+1:]:
-                    c2.child.terminate()
+                    c2.child.flush_results()
                 raise
 
             results.append(result)
@@ -367,19 +433,10 @@ class Pool:
         if error_callback:
             raise NotImplementedError("error_callback not implemented")
 
-        if self._closed:
-            raise ValueError("Pool already closed")
-        if kwds is None:
-            kwds = {}
+        results = self._apply_batch_async(func, [args], [kwds])
+        assert len(results) == 1
+        return results[0]
 
-
-        # choose the first idle process if there is one
-        # if not, choose the process with the shortest queue
-        for c in self.children:
-            c.flush()
-        min_q_sz = min(c.queue_sz for c in self.children)
-        c = random.choice([c for c in self.children if c.queue_sz <= min_q_sz])
-        return c.submit(func, args, kwds)
 
     def map_async(self, func, iterable, chunksize=None, callback=None, error_callback=None) -> AsyncResult:
         return self.starmap_async(func, zip(iterable), chunksize, callback, error_callback)
@@ -392,12 +449,42 @@ class Pool:
             raise NotImplementedError("Haven't implemented chunksizes. Infinite chunksize only.")
         if callback or error_callback:
             raise NotImplementedError("Haven't implemented callbacks")
-        results = [self.apply_async(func, args) for args in iterable]
 
-        # aggregate into one result
+        results = self._apply_batch_async(func, args_iterable=iterable, kwds_iterable=repeat({}))
         result = AsyncResultList(child_results=results)
-
         return result
+
+    # like starmap, but has argument for keyword args
+    # so apply_async can call this
+    # (apply_async supports kwargs but starmap_async does not)
+    def _apply_batch_async(self, func, args_iterable: Iterable[Iterable], kwds_iterable: Iterable[Dict]) -> List[AsyncResult]:
+        if self._closed:
+            raise ValueError("Pool already closed")
+
+        for c in self.children:
+            c.flush_results()
+
+        results = []
+        children_called = set()
+        for (args, kwds) in zip(args_iterable, kwds_iterable):
+            child = self._choose_child() # already flushed results
+            children_called.add(child)
+            result = child.submit(func, args, kwds, as_batch=True)
+            results.append(result)
+
+        for child in children_called:
+            child.run_batch()
+
+        return results
+        
+
+    # return the child with the shortest queue
+    # if a tie, choose randomly
+    # You should call c.flush_results() first before calling this
+    def _choose_child(self) -> Child:
+        min_q_sz = min(c.queue_sz for c in self.children)
+        return random.choice([c for c in self.children if c.queue_sz <= min_q_sz])
+
 
     def starmap(self, func, iterable: Iterable[Iterable], chunksize=None, callback=None, error_callback=None) -> List[Any]:
         if chunksize:
@@ -423,7 +510,7 @@ class Pool:
                 for child in self.children:
                     if child.parent_conn in ready:
                         assert child.parent_conn.poll()
-                        child.flush()
+                        child.flush_results()
                         idle_children.add(child)
                 
 

--- a/lambda_multiprocessing/test_main.py
+++ b/lambda_multiprocessing/test_main.py
@@ -334,11 +334,14 @@ class TestMapAsync(TestCase):
         self.assertEqual(results, [square(e) for e in args])
 
     def test_duration(self):
-        n = 2
-        with self.pool_generator(n) as p:
-            with self.assertDuration(min_t=(n-1)-delta, max_t=(n+1)+delta):
+        sleep_duration = 0.5
+        n_procs = 2
+        num_tasks_per_proc = 2
+        expected_wall_time = sleep_duration * num_tasks_per_proc
+        with self.pool_generator(n_procs) as p:
+            with self.assertDuration(min_t=expected_wall_time-delta, max_t=expected_wall_time+delta):
                 with self.assertDuration(max_t=delta):
-                    results = p.map_async(sleep, range(n))
+                    results = p.map_async(sleep, [1] * (num_tasks_per_proc * n_procs))
                 results.get()
 
     def test_error_handling(self):

--- a/lambda_multiprocessing/test_main.py
+++ b/lambda_multiprocessing/test_main.py
@@ -5,11 +5,22 @@ from time import time, sleep
 from typing import Tuple, Optional
 from pathlib import Path
 import os
-from functools import cache
+import sys
+
 
 import boto3
 from moto import mock_aws
 from lambda_multiprocessing.timeout import TimeoutManager, TestTimeoutException
+
+if sys.version_info < (3, 9):
+    # functools.cache was added in 3.9
+    # define an empty decorator that doesn't do anything
+    # (our usage of the cache isn't essential)
+    def cache(func):
+        return func
+else:
+    # Import the cache function from functools for Python 3.9 and above
+    from functools import cache
 
 # add an overhead for duration when asserting the duration of child processes
 # if other processes are hogging CPU, make this bigger
@@ -39,7 +50,7 @@ def return_with_sleep(x, delay=0.3):
 
 def _raise(ex: Optional[Exception]):
     if ex:
-        raise exfrom .timeout
+        raise ex
 
 class ExceptionA(Exception):
     pass

--- a/lambda_multiprocessing/test_main.py
+++ b/lambda_multiprocessing/test_main.py
@@ -9,7 +9,7 @@ from functools import cache
 
 import boto3
 from moto import mock_aws
-from timeout import TimeoutManager, TestTimeoutException
+from lambda_multiprocessing.timeout import TimeoutManager, TestTimeoutException
 
 # add an overhead for duration when asserting the duration of child processes
 # if other processes are hogging CPU, make this bigger
@@ -39,7 +39,7 @@ def return_with_sleep(x, delay=0.3):
 
 def _raise(ex: Optional[Exception]):
     if ex:
-        raise ex
+        raise exfrom .timeout
 
 class ExceptionA(Exception):
     pass
@@ -73,7 +73,7 @@ class TestCase(unittest.TestCase):
     # For a potential eternal task, use timeout.TimeoutManager
     def assertDuration(self, min_t=None, max_t=None):
         class AssertDuration:
-            def __init__(self, test):
+            def __init__(self, test: unittest.TestCase):
                 self.test = test
             def __enter__(self):
                 self.start_t = time()

--- a/lambda_multiprocessing/timeout.py
+++ b/lambda_multiprocessing/timeout.py
@@ -1,0 +1,35 @@
+# Timeout context manager for unit testing
+
+import signal
+from math import ceil
+
+class TestTimeoutException(Exception):
+    """Exception raised when a test takes too long"""
+    pass
+
+class TimeoutManager:
+    # if a float is passed as seconds, it will be rounded up
+    def __init__(self, seconds: int, description = "Test timed out"):
+        self.seconds = ceil(seconds)
+        self.description = description
+        self.old_handler = None
+
+    def __enter__(self):
+        self.old_handler = signal.signal(signal.SIGALRM, self.timeout_handler)
+        signal.alarm(self.seconds)
+        return self
+
+    def timeout_handler(self, signum, frame):
+        raise TestTimeoutException(self.description)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # Disable the alarm
+        signal.alarm(0)
+        # Restore old signal handler
+        signal.signal(signal.SIGALRM, self.old_handler)
+
+        if exc_type is TestTimeoutException:
+            return False  # Let the TestTimeoutException exception propagate
+            
+        # Propagate any other exceptions, or continue if no exception
+        return False


### PR DESCRIPTION
Partially solves #17

* rewrite `starmap` scheduler to not give tasks to children until they've returned the previous result
* add unit test for deadlock issues
* rewrite map_async to return a single result, instead of list of results. (I should probably have done this in a different PR, but I'm being lazy because I don't have much time right now.)